### PR TITLE
get normals sum in zero fix

### DIFF
--- a/volmdlr/stl.py
+++ b/volmdlr/stl.py
@@ -266,7 +266,12 @@ class Stl(dc.DessiaObject):
             for point in value:
                 point_normal += point
             points_normals[key] = point_normal
-            point_normal.normalize()
+            try :
+                point_normal.normalize()
+            except ZeroDivisionError:
+                point_normal = value[0]
+                points_normals[key] = point_normal
+                point_normal.normalize()
             normals.append(point_normal)
         self.normals = normals
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit messages follows our guidelines (explicit, in english)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bug fix: in stl.get_normals, the sum of point_normal is vm.O3D, here is a fix
- [ ] New features:
- [ ] Documentation
- [ ] Optimization

* **Other information**:

