### PR TITLE
fix: offset of linesegment was not using unit normal vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Contour2D: point_belongs (bug when contour has only one primitive, like FullArc2D)
 * Contour: contours_from_edges
 * PlaneFace3D: face_intersections
-
+* infinite primitive offset of linesegment
 
 ### Performance improvements
 

--- a/volmdlr/edges.py
+++ b/volmdlr/edges.py
@@ -1348,7 +1348,7 @@ class LineSegment2D(LineSegment):
         return circle1, circle2
 
     def infinite_primitive(self, offset):
-        n = self.normal_vector()
+        n = self.unit_normal_vector()
         offset_point_1 = self.start + offset * \
             n
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit messages follows our guidelines (explicit, in english)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bug fix: infinite primitive was using normal vector which was not normalize

* **Other information**:

