### PR TITLE
fix(barrels): stop importing from dessia_common directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unrealeased
 
+### Changes
+
+* Import from dessia_common are now performed from dessia_common.core
+
 ## v0.6.0 [11/7/2022]
 
 ### New Features

--- a/scripts/faces/BSplineSurface/bspline_surface_definition.py
+++ b/scripts/faces/BSplineSurface/bspline_surface_definition.py
@@ -186,5 +186,5 @@ bspline_face = bspline_surface.rectangular_cut(0, 1, 0, 1)
 # bspline_face.babylonjs()
 
 import json
-import dessia_common as dc
+import dessia_common.core as dc
 bspline_face2 = dc.DessiaObject.dict_to_object(json.loads(json.dumps(bspline_face.to_dict())))

--- a/scripts/mesh/mesher.py
+++ b/scripts/mesh/mesher.py
@@ -12,7 +12,7 @@ from scipy import sparse
 from scipy import linalg
 from finite_elements.core import steel,aluminium
 import time 
-from dessia_common import DessiaObject
+from dessia_common.core import DessiaObject
 from typing import TypeVar, List, Tuple
 from scipy.spatial import Delaunay
 from itertools import product 

--- a/tests/faces/test_planeface3d.py
+++ b/tests/faces/test_planeface3d.py
@@ -3,13 +3,13 @@ Tests for places faces
 """
 import unittest
 
-import dessia_common
+import dessia_common.core as dc
 import volmdlr
 
 
 class TestPlaneFace3D(unittest.TestCase):
-    face_with_3holes = dessia_common.DessiaObject.load_from_file('faces/face_with_3holes.json')
-    face = dessia_common.DessiaObject.load_from_file('faces/face_to_cut_the_one_with_3holes.json')
+    face_with_3holes = dc.DessiaObject.load_from_file('faces/face_with_3holes.json')
+    face = dc.DessiaObject.load_from_file('faces/face_to_cut_the_one_with_3holes.json')
 
     def test_area(self):
         self.assertAlmostEqual(self.face_with_3holes.area(), 0.12160000)

--- a/volmdlr/cloud.py
+++ b/volmdlr/cloud.py
@@ -8,7 +8,7 @@ from typing import List
 
 import matplotlib.pyplot as plt
 
-import dessia_common as dc
+import dessia_common.core as dc
 import volmdlr as vm
 # import volmdlr.core
 import volmdlr.wires as vmw

--- a/volmdlr/core.py
+++ b/volmdlr/core.py
@@ -16,7 +16,7 @@ from typing import List
 import matplotlib.pyplot as plt
 import numpy as npy
 
-import dessia_common as dc
+import dessia_common.core as dc
 import dessia_common.files as dcf
 import volmdlr
 import volmdlr.templates

--- a/volmdlr/core_compiled.pyx
+++ b/volmdlr/core_compiled.pyx
@@ -17,7 +17,7 @@ from mpl_toolkits.mplot3d import proj3d
 import matplotlib.pyplot as plt
 from matplotlib.patches import FancyArrow, FancyArrowPatch
 
-from dessia_common import DessiaObject
+from dessia_common.core import DessiaObject
 import plot_data
 
 # =============================================================================

--- a/volmdlr/display.py
+++ b/volmdlr/display.py
@@ -5,7 +5,7 @@
 """
 from typing import List, Tuple
 import math
-import dessia_common as dc
+import dessia_common.core as dc
 import volmdlr.edges
 # import volmdlr.faces as vmf
 

--- a/volmdlr/edges.py
+++ b/volmdlr/edges.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 import matplotlib.patches
 
 import plot_data.core as plot_data
-import dessia_common as dc
+import dessia_common.core as dc
 import volmdlr.core_compiled
 import volmdlr.core
 import volmdlr.geometry

--- a/volmdlr/gmsh_vm.py
+++ b/volmdlr/gmsh_vm.py
@@ -4,7 +4,7 @@
 Gmsh and related objects
 """
 
-from dessia_common import DessiaObject
+from dessia_common.core import DessiaObject
 import volmdlr
 import volmdlr.mesh
 

--- a/volmdlr/grid.py
+++ b/volmdlr/grid.py
@@ -7,7 +7,7 @@ Module containing grid and relative objects
 
 from typing import List
 import numpy as npy
-from dessia_common import DessiaObject
+from dessia_common.core import DessiaObject
 import volmdlr
 import volmdlr.wires
 

--- a/volmdlr/mesh.py
+++ b/volmdlr/mesh.py
@@ -9,7 +9,7 @@ from itertools import combinations
 import math
 import matplotlib.pyplot as plt
 import numpy as npy
-from dessia_common import DessiaObject
+from dessia_common.core import DessiaObject
 # import volmdlr.core_compiled
 import volmdlr as vm
 import volmdlr.wires as vmw

--- a/volmdlr/primitives3d.py
+++ b/volmdlr/primitives3d.py
@@ -12,7 +12,7 @@ from scipy.optimize import minimize, NonlinearConstraint
 import numpy as npy
 import matplotlib.pyplot as plt
 
-import dessia_common as dc
+import dessia_common.core as dc
 import volmdlr
 import volmdlr.core
 import volmdlr.primitives

--- a/volmdlr/step.py
+++ b/volmdlr/step.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import plot_data.graph
 
-import dessia_common as dc
+import dessia_common.core as dc
 
 import volmdlr
 import volmdlr.core

--- a/volmdlr/stl.py
+++ b/volmdlr/stl.py
@@ -14,7 +14,7 @@ from binaryornot.check import is_binary
 # import kaitaistruct
 from kaitaistruct import KaitaiStream
 
-import dessia_common as dc
+import dessia_common.core as dc
 import volmdlr as vm
 import volmdlr.core as vmc
 import volmdlr.faces as vmf


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages follows our guidelines (explicit, in english)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bug fix: Remove direct dessia_common imports
- [ ] New features:
- [ ] Documentation
- [ ] Optimization

* **Other information**:
I didn't realise this would be necessary in order to make dessia_common ci pass, but as dessia_common imports volmdlr (and plot_data) without actually requiring them, making the change in volmdlr **before** dessia_common is actually mandatory. This is because, otherwise, volmdlr cannot install anymore and is not importable (it imports Dessia from dessia_common, but it is not available anymore in current dc version trying to pass its ci). So this is actually a prerequisite for dessia_common

**That is why I set the merging directly to master, as dessia_common will require it to be released in order to pass its CI. As it is not breaking, I guess it can be merged to master and then released as a patch**



