### PR TITLE
fix: restrict cibuildwheel to py3.12

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,6 +7,7 @@ on:
    push:
      branches:
       - master
+      - fix/ci
 
 jobs:
   build_wheels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
 requires = ["setuptools", "Cython>=3", "numpy<1.26.0"]
+
+
+[tool.cibuildwheel]
+# Skip building on CPython 3.12 on all platforms. remove in the future
+skip = "cp312-*"


### PR DESCRIPTION
Try to debug cibuildwheel by removing build for python3.12